### PR TITLE
Align curve name for Ed25519 and X25519

### DIFF
--- a/w3c-spec/PRISM-method.md
+++ b/w3c-spec/PRISM-method.md
@@ -35,8 +35,8 @@ This document describes the first version of the `prism` DID method. Each versio
 | `MAX_SERVICE_NUMBER` | Maximum number of active services a DID Document can have at the same time. | 50 |
 | `MAX_VERIFICATION_METHOD_NUMBER` | Maximum number of active keys a DID can have at the same time. Note that this includes keys with `usage` `MASTER_KEY` and `REVOCATION_KEY` | 50 |
 | `SECP256K1_CURVE_NAME` | String identifier for the SECP256K1 eliptic curve | "secp256k1" |
-| `ED25519_CURVE_NAME` | String identifier for the ED25519 eliptic curve | "ed25519" |
-| `X25519_CURVE_NAME` | String identifier for the Curve25519 eliptic curve | "x25519" |
+| `ED25519_CURVE_NAME` | String identifier for the ED25519 eliptic curve | "Ed25519" |
+| `X25519_CURVE_NAME` | String identifier for the Curve25519 eliptic curve | "X25519" |
 
 `*` These values will be filled in once the mainnet deployment is confirmed.
 


### PR DESCRIPTION
In the protobuf message and the DID document, we use slightly different curve names to represent the same curve.

| curve name in protobuf | curve name in jwk |
|-|-|
| `ed25519` | `Ed25519` |
| `x25519` | `X25519` |

Keeping the name consistent with the https://www.iana.org/assignments/jose/jose.xhtml should provide more consistency and reduce implementation errors where different names are used in different places.